### PR TITLE
Add shflags as external dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/shflags"]
+	path = external/shflags
+	url = git@github.com:kward/shflags.git


### PR DESCRIPTION
I have add the `kward/shflags` repository as a git submodule. The intention being to make it simpler to add flags to some of the build scripts.