### PR TITLE
Segregate window and shader code

### DIFF
--- a/glfw/Makefile
+++ b/glfw/Makefile
@@ -10,4 +10,4 @@ clean:
 glfw-test: src/glad.c main.c
 	$(CC) $(CFLAGS) src/glad.c main.c -o $@ -lglfw -lGL -lX11 -lpthread -lXrandr -lXi -ldl
 glfw-testxx: main.cpp
-	$(CXX) $(CXXFLAGS) main.cpp src/glad.c -o $@ -lglfw -lGL -lX11 -lpthread -lXrandr -lXi -ldl
+	$(CXX) $(CXXFLAGS) main.cpp src/window.c src/shader.c src/glad.c -o $@ -lglfw -lGL -lX11 -lpthread -lXrandr -lXi -ldl

--- a/glfw/include/shader.h
+++ b/glfw/include/shader.h
@@ -1,0 +1,20 @@
+#ifndef __MISC_BASILE_GLFW_SHADER_H__
+#define __MISC_BASILE_GLFW_SHADER_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct rps_shader__ rps_shader_t;
+
+extern rps_shader_t *rps_shader_new(const char *, const char *);
+extern void rps_shader_render(const rps_shader_t *);
+extern void rps_shader_free(rps_shader_t **);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __MISC_BASILE_GLFW_SHADER_H__

--- a/glfw/include/window.h
+++ b/glfw/include/window.h
@@ -1,0 +1,21 @@
+#ifndef __MISC_BASILE_GLFW_WINDOW_H__
+#define __MISC_BASILE_GLFW_WINDOW_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct rps_window__ rps_window_t;
+
+
+extern rps_window_t *rps_window_new(void);
+extern void rps_window_free(rps_window_t **);
+extern void rps_window_run(rps_window_t *);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !__MISC_BASILE_GLFW_WINDOW_H__ */

--- a/glfw/main.cpp
+++ b/glfw/main.cpp
@@ -1,93 +1,6 @@
-#include "include/glad/glad.h"
-#include <GLFW/glfw3.h>
-
-#include <iostream>
-
-
-typedef GLFWwindow rps_window_t;
-
-static rps_window_t *rps_window_new(void);
-static void rps_window_close(rps_window_t *);
-static void rps_window_run(rps_window_t *);
-
-static void rps_window_eventhnd__(rps_window_t *);
-static void rps_window_resize__(rps_window_t *, int, int);
-
-
-// Creates new GLFW window
-rps_window_t *rps_window_new(void)
-{
-    glfwInit();
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-    const int width = 800;
-    const int height = 600;
-    const char *title = "RefPerSys";
-
-    GLFWwindow* ctx = glfwCreateWindow(width, height, title, NULL, NULL);
-
-    if (!ctx) {
-        std::cout << "Failed to create GLFW window" << std::endl;
-        glfwTerminate();
-        abort();
-    }
-
-    glfwMakeContextCurrent(ctx);
-    glfwSetFramebufferSizeCallback(ctx, rps_window_resize__);
-
-    if (!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress)) {
-        std::cout << "Failed to initialize GLAD" << std::endl;
-        glfwTerminate();
-        abort();
-    }
-
-    return ctx;
-}
-
-
-// Closes window
-void
-rps_window_close(rps_window_t *ctx)
-{
-    (void) ctx; // will be used later
-    glfwTerminate();
-}
-
-
-// Main window event loop
-void
-rps_window_run(rps_window_t *ctx)
-{
-    while (!glfwWindowShouldClose(ctx)) {
-        rps_window_eventhnd__(ctx);
-
-        glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT);
-        glfwSwapBuffers(ctx);
-
-        glfwPollEvents();
-    }
-}
-
-
-// Callback to handle window events
-void
-rps_window_eventhnd__(rps_window_t *ctx)
-{
-    if (glfwGetKey(ctx, GLFW_KEY_ESCAPE) == GLFW_PRESS)
-        glfwSetWindowShouldClose(ctx, true);
-}
-
-
-// Callback on window resize
-void
-rps_window_resize__(rps_window_t *ctx, int w, int h)
-{
-    (void) ctx; // will be used later
-    glViewport(0, 0, w, h);
-}
+#include "include/window.h"
+#include <stdio.h>
+#include <stdlib.h>
 
 
 int main(int argc, char **argv)
@@ -97,7 +10,7 @@ int main(int argc, char **argv)
 
     rps_window_t *w = rps_window_new();
     rps_window_run(w);
-    rps_window_close(w);
+    rps_window_free(&w);
 
     return EXIT_SUCCESS;
 }
@@ -105,9 +18,6 @@ int main(int argc, char **argv)
 
 ///// DEPRECATED; kept only for reference; will be removed
 #if 0
-void framebfrsz_cbk(GLFWwindow* window, int width, int height);
-void proc_input(GLFWwindow *window);
-
 
 const unsigned int SCR_WIDTH = 800;
 const unsigned int SCR_HEIGHT = 600;
@@ -229,16 +139,5 @@ int main(void)
     glfwTerminate();
 
     return 0;
-}
-
-void proc_input(GLFWwindow *window)
-{
-    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
-        glfwSetWindowShouldClose(window, true);
-}
-
-void framebfrsz_cbk(GLFWwindow* window, int width, int height)
-{
-    glViewport(0, 0, width, height);
 }
 #endif

--- a/glfw/src/shader.c
+++ b/glfw/src/shader.c
@@ -1,0 +1,82 @@
+#include "../include/shader.h"
+#include "../include/glad/glad.h"
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+struct rps_shader__ {
+    unsigned int program;
+};
+
+
+rps_shader_t *
+rps_shader_new(const char *vertex_src, const char *fragment_src)
+{
+    unsigned int vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+    int success;
+    char info_log[512];
+
+    glShaderSource(vertex_shader, 1, &vertex_src, NULL);
+    glCompileShader(vertex_shader);
+    glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &success);
+
+    if (!success) {
+        glGetShaderInfoLog(vertex_shader, 512, NULL, info_log);
+        printf("Vertex shader compilation failed: %s\n", info_log);
+    }
+
+    unsigned int fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragment_shader, 1, &fragment_src, NULL);
+    glCompileShader(fragment_shader);
+    glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &success);
+
+    if (!success) {
+        glGetShaderInfoLog(fragment_shader, 512, NULL, info_log);
+        printf("Fragment compilation failed: %s\n", info_log);
+    }
+
+    rps_shader_t *ctx = (rps_shader_t *) malloc(sizeof *ctx);
+
+    if (!ctx) {
+        printf("Failed to allocate memory for shader!\n");
+        abort();
+    }
+
+    ctx->program = glCreateProgram();
+    glAttachShader(ctx->program, vertex_shader);
+    glAttachShader(ctx->program, fragment_shader);
+    glLinkProgram(ctx->program);
+    glGetProgramiv(ctx->program, GL_LINK_STATUS, &success);
+
+    if (!success) {
+        glGetProgramInfoLog(ctx->program, 512, NULL, info_log);
+        printf("Shader linking failed: %s\n", info_log);
+    }
+
+    glDeleteShader(vertex_shader);
+    glDeleteShader(fragment_shader);
+
+    return ctx;
+}
+
+
+void
+rps_shader_render(const rps_shader_t *ctx)
+{
+    glUseProgram(ctx->program);
+}
+
+
+void
+rps_shader_close(rps_shader_t **ctx)
+{
+    rps_shader_t *s;
+
+    if (ctx && (s = *ctx)) {
+        glDeleteProgram(s->program);
+        free(s);
+    }
+
+    *ctx = NULL;
+}

--- a/glfw/src/window.c
+++ b/glfw/src/window.c
@@ -1,0 +1,103 @@
+#include "../include/window.h"
+#include "../include/glad/glad.h"
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+
+struct rps_window__ {
+        GLFWwindow *wnd;
+};
+
+
+static void rps_window_eventhnd__(rps_window_t *);
+static void rps_window_resize__(GLFWwindow *, int, int);
+
+
+// Creates new GLFW window
+rps_window_t *rps_window_new(void)
+{
+    glfwInit();
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+    const int width = 800;
+    const int height = 600;
+    const char *title = "RefPerSys";
+
+    rps_window_t *ctx = (rps_window_t *) malloc(sizeof (*ctx));
+    if (!ctx) {
+            printf("Failed to allocated memory for rps_window_t!\n");
+            abort();
+    }
+
+    ctx->wnd = glfwCreateWindow(width, height, title, NULL, NULL);
+
+    if (!ctx->wnd) {
+        printf("Failed to create GLFW window\n");
+        glfwTerminate();
+        abort();
+    }
+
+    glfwMakeContextCurrent(ctx->wnd);
+    glfwSetFramebufferSizeCallback(ctx->wnd, rps_window_resize__);
+
+    if (!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress)) {
+        printf("Failed to initialize GLAD\n");
+        glfwTerminate();
+        abort();
+    }
+
+    return ctx;
+}
+
+
+// Closes window
+void
+rps_window_free(rps_window_t **ctx)
+{
+        rps_window_t *w;
+
+        if (ctx && (w = *ctx)) {
+            glfwTerminate();
+            free(w);
+        }
+
+        *ctx = NULL;
+}
+
+
+// Main window event loop
+void
+rps_window_run(rps_window_t *ctx)
+{
+        while (!glfwWindowShouldClose(ctx->wnd)) {
+                rps_window_eventhnd__(ctx);
+
+                glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+                glClear(GL_COLOR_BUFFER_BIT);
+                glfwSwapBuffers(ctx->wnd);
+
+                glfwPollEvents();
+        }
+}
+
+
+// Callback to handle window events
+void
+rps_window_eventhnd__(rps_window_t *ctx)
+{
+    if (glfwGetKey(ctx->wnd, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+        glfwSetWindowShouldClose(ctx->wnd, true);
+}
+
+
+// Callback on window resize
+void
+rps_window_resize__(GLFWwindow *ctx, int w, int h)
+{
+    (void) ctx; // will be used later
+    glViewport(0, 0, w, h);
+}


### PR DESCRIPTION
The window and shader code were tightly integrated together in the
earlier commit. We have now segregated the shader and window code, and
will later inject the shader into the window. The shader also requires
a vertex data structure, but that has not yet been implemented. Once the
vertex data structure is in place, we will be able to render the shader
geometries alongside the ImGUI widgets in every frame. This is expected
to be completed within the next two commits.

Signed-off-by: Abhishek Chakravarti <abhishek@taranjali.org>